### PR TITLE
bug: Dinoframe was incorrectly filtering service records to get http records

### DIFF
--- a/src/dinoframe.ts
+++ b/src/dinoframe.ts
@@ -23,6 +23,7 @@ import {
 } from "./service-container/common/runtime";
 import { ID_LOGGER } from "./service-container/common/logging";
 import { ClassServiceMetadata } from "./service-container/types";
+import {getHttpMetaByGids} from "./http/decorators";
 
 export class Dinoframe {
   static readonly ID_EXPRESS_APP = "express.app";
@@ -120,10 +121,8 @@ export class Dinoframe {
     }
 
     // 3. now register http stuff after services load
-    const controllers = filterMetadataByProvider(
-      meta,
-      require("./http").PROVIDER_ID
-    );
+    const controllers = getHttpMetaByGids(meta.map(rec => rec.gid));
+    console.log('CONTROLLERS=', JSON.stringify(controllers,null, '  '))
     this.processHttpDecorators(controllers);
   }
 

--- a/src/http/decorators.ts
+++ b/src/http/decorators.ts
@@ -89,3 +89,7 @@ export const RequestParam = (
 };
 
 export const getHttpAnnotations = () => collector.getFinalized();
+
+export const getHttpMetaByGids = (gids: string[]) => {
+  return collector.getFinalized().filter(rec => gids.includes(rec.gid));
+}


### PR DESCRIPTION
before: filtering service records by http provider id
after: filtering http decorators directly by gids of service records
caveat: all controllers must be marked as `@Service`